### PR TITLE
🚀 version changed packages

### DIFF
--- a/.changeset/flat-bobcats-wait.md
+++ b/.changeset/flat-bobcats-wait.md
@@ -1,7 +1,0 @@
----
-"@naverpay/device-info": patch
----
-
-feat: add latest iPhone models to iOS data
-
-PR: [feat: add latest iPhone models to iOS data](https://github.com/NaverPayDev/device-info/pull/95)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @naverpay/device-info
 
+## 1.0.26
+
+### Patch Changes
+
+- c18fd34: feat: add latest iPhone models to iOS data
+
+  PR: [feat: add latest iPhone models to iOS data](https://github.com/NaverPayDev/device-info/pull/95)
+
 ## 1.0.25
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@naverpay/device-info",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "description": "Device information",
   "scripts": {
     "build": "tsup",


### PR DESCRIPTION
# Releases
## @naverpay/device-info@1.0.26

### Patch Changes

-   c18fd34: feat: add latest iPhone models to iOS data

    PR: [feat: add latest iPhone models to iOS data](https://github.com/NaverPayDev/device-info/pull/95)
