### PR TITLE
🚀 version changed packages

### DIFF
--- a/.changeset/lazy-pants-kneel.md
+++ b/.changeset/lazy-pants-kneel.md
@@ -1,7 +1,0 @@
----
-"@naverpay/device-info": patch
----
-
-Weekly Device Info Update
-
-PR: [Weekly Device Info Update](https://github.com/NaverPayDev/device-info/pull/94)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @naverpay/device-info
 
+## 1.0.27
+
+### Patch Changes
+
+- f032156: Weekly Device Info Update
+
+  PR: [Weekly Device Info Update](https://github.com/NaverPayDev/device-info/pull/94)
+
 ## 1.0.26
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@naverpay/device-info",
-  "version": "1.0.26",
+  "version": "1.0.27",
   "description": "Device information",
   "scripts": {
     "build": "tsup",


### PR DESCRIPTION
# Releases
## @naverpay/device-info@1.0.27

### Patch Changes

-   f032156: Weekly Device Info Update

    PR: [Weekly Device Info Update](https://github.com/NaverPayDev/device-info/pull/94)
