### PR TITLE
🚀 version changed packages

### DIFF
--- a/.changeset/legal-papers-follow.md
+++ b/.changeset/legal-papers-follow.md
@@ -1,7 +1,0 @@
----
-"@naverpay/device-info": minor
----
-
-support subpath exports
-
-PR: [subpath exports 지원](https://github.com/NaverPayDev/device-info/pull/109)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @naverpay/device-info
 
+## 1.1.0
+
+### Minor Changes
+
+- 4376c74: support subpath exports
+
+  PR: [subpath exports 지원](https://github.com/NaverPayDev/device-info/pull/109)
+
 ## 1.0.29
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@naverpay/device-info",
-  "version": "1.0.29",
+  "version": "1.1.0",
   "description": "Device information",
   "scripts": {
     "build": "tsup",


### PR DESCRIPTION
# Releases
## @naverpay/device-info@1.1.0

### Minor Changes

-   4376c74: support subpath exports

    PR: [subpath exports 지원](https://github.com/NaverPayDev/device-info/pull/109)
